### PR TITLE
fix: update zakat ID and timestamp formats in test chaincode, fixes #1

### DIFF
--- a/scripts/demo/04_test_chaincode.sh
+++ b/scripts/demo/04_test_chaincode.sh
@@ -16,7 +16,7 @@ format_json() {
 echo "Test 1: Adding a new zakat transaction..."
 echo " Invoking chaincode on YDSFMalang..."
 echo " Command to be executed:"
-echo " peer chaincode invoke -C zakat-channel -n zakat -c '{\"function\":\"AddZakat\",\"Args\":[\"zakat1\", \"afif\", \"2500000\", \"maal\", \"YDSFMalang\", \"2024-11-26\"]}'"
+echo " peer chaincode invoke -C zakat-channel -n zakat -c '{\"function\":\"AddZakat\",\"Args\":[\"ZKT-YDSF-MLG-202401-0001\", \"afif\", \"2500000\", \"maal\", \"YDSF Malang\", \"2024-01-26T12:00:00Z\"]}'"
 echo
 RESULT=$(docker run --rm \
   -v ${FABRIC_ZAKAT_PATH}:/opt/fabric-zakat \
@@ -28,7 +28,7 @@ RESULT=$(docker run --rm \
   -e CORE_PEER_MSPCONFIGPATH=/opt/fabric-zakat/organizations/peerOrganizations/ydsfmalang.example.local/users/Admin@ydsfmalang.example.local/msp \
   -e CORE_PEER_ADDRESS=peer0.ydsfmalang.example.local:7051 \
   hyperledger/fabric-tools:2.4 \
-  peer chaincode invoke -o orderer.example.local:7050 --tls --cafile /opt/fabric-zakat/organizations/ordererOrganizations/example.local/orderers/orderer.example.local/msp/tlscacerts/tlsca.example.local-cert.pem -C zakat-channel -n zakat -c '{"function":"AddZakat","Args":["zakat1", "afif", "2500000", "maal", "YDSFMalang", "2024-11-26"]}')
+  peer chaincode invoke -o orderer.example.local:7050 --tls --cafile /opt/fabric-zakat/organizations/ordererOrganizations/example.local/orderers/orderer.example.local/msp/tlscacerts/tlsca.example.local-cert.pem -C zakat-channel -n zakat -c '{"function":"AddZakat","Args":["ZKT-YDSF-MLG-202401-0001", "afif", "2500000", "maal", "YDSF Malang", "2024-01-26T12:00:00Z"]}')
 format_json "$RESULT"
 
 # Wait for transaction to be committed
@@ -38,7 +38,7 @@ sleep 5
 echo -e "\nTest 2: Querying zakat details..."
 echo " Querying chaincode on YDSFMalang..."
 echo " Command to be executed:"
-echo " peer chaincode query -C zakat-channel -n zakat -c '{\"function\":\"QueryZakat\",\"Args\":[\"zakat1\"]}'"
+echo " peer chaincode query -C zakat-channel -n zakat -c '{\"function\":\"QueryZakat\",\"Args\":[\"ZKT-YDSF-MLG-202401-0001\"]}'"
 echo
 RESULT=$(docker run --rm \
   -v ${FABRIC_ZAKAT_PATH}:/opt/fabric-zakat \
@@ -50,7 +50,7 @@ RESULT=$(docker run --rm \
   -e CORE_PEER_MSPCONFIGPATH=/opt/fabric-zakat/organizations/peerOrganizations/ydsfmalang.example.local/users/Admin@ydsfmalang.example.local/msp \
   -e CORE_PEER_ADDRESS=peer0.ydsfmalang.example.local:7051 \
   hyperledger/fabric-tools:2.4 \
-  peer chaincode query -C zakat-channel -n zakat -c '{"function":"QueryZakat","Args":["zakat1"]}')
+  peer chaincode query -C zakat-channel -n zakat -c '{"function":"QueryZakat","Args":["ZKT-YDSF-MLG-202401-0001"]}')
 format_json "$RESULT"
 
 # Wait for query to complete
@@ -60,7 +60,7 @@ sleep 2
 echo -e "\nTest 3: Distributing zakat..."
 echo " Invoking chaincode on YDSFJatim..."
 echo " Command to be executed:"
-echo " peer chaincode invoke -C zakat-channel -n zakat -c '{\"function\":\"DistributeZakat\",\"Args\":[\"zakat1\", \"ahmad\", \"500000\", \"2024-11-26\"]}'"
+echo " peer chaincode invoke -C zakat-channel -n zakat -c '{\"function\":\"DistributeZakat\",\"Args\":[\"ZKT-YDSF-MLG-202401-0001\", \"ahmad\", \"500000\", \"2024-01-26T12:00:00Z\"]}'"
 echo
 RESULT=$(docker run --rm \
   -v ${FABRIC_ZAKAT_PATH}:/opt/fabric-zakat \
@@ -72,7 +72,7 @@ RESULT=$(docker run --rm \
   -e CORE_PEER_MSPCONFIGPATH=/opt/fabric-zakat/organizations/peerOrganizations/ydsfjatim.example.local/users/Admin@ydsfjatim.example.local/msp \
   -e CORE_PEER_ADDRESS=peer0.ydsfjatim.example.local:8051 \
   hyperledger/fabric-tools:2.4 \
-  peer chaincode invoke -o orderer.example.local:7050 --tls --cafile /opt/fabric-zakat/organizations/ordererOrganizations/example.local/orderers/orderer.example.local/msp/tlscacerts/tlsca.example.local-cert.pem -C zakat-channel -n zakat -c '{"function":"DistributeZakat","Args":["zakat1", "ahmad", "500000", "2024-11-26"]}')
+  peer chaincode invoke -o orderer.example.local:7050 --tls --cafile /opt/fabric-zakat/organizations/ordererOrganizations/example.local/orderers/orderer.example.local/msp/tlscacerts/tlsca.example.local-cert.pem -C zakat-channel -n zakat -c '{"function":"DistributeZakat","Args":["ZKT-YDSF-MLG-202401-0001", "ahmad", "500000", "2024-01-26T12:00:00Z"]}')
 format_json "$RESULT"
 
 # Wait for distribution to be committed


### PR DESCRIPTION
# Fix Invalid Formats in Test Chaincode

## Description
Updates the test chaincode to use correct formats for Zakat ID and timestamps that match the validation requirements in the smart contract.

## Changes Made
1. Updated Zakat ID format from simple `zakat1` to proper format `ZKT-YDSF-MLG-202401-0001`
2. Updated timestamp format from `YYYY-MM-DD` to ISO 8601 format `YYYY-MM-DDThh:mm:ssZ`

## Test Results
- [x] AddZakat test passes with new ID format
- [x] QueryZakat test passes with new ID format
- [x] DistributeZakat test passes with new timestamp format
- [x] GetAllZakat returns properly formatted data

## Related Issues
Fixes #1

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [x] My code follows the proper format guidelines
- [x] I have tested my changes
- [x] My changes generate no new warnings